### PR TITLE
Update db service to version and environment

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -15,11 +15,13 @@ services:
       restart_policy:
         condition: on-failure
   db:
-    image: postgres:9.4
+    image: postgres:9.6-alpine
     volumes:
       - db-data:/var/lib/postgresql/data
     networks:
       - backend
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
     deploy:
       placement:
         constraints: [node.role == manager]


### PR DESCRIPTION
Update Postgres to 9.6
set environment variable to allow connection without a password
See http://support.divio.com/en/articles/3719228-database-is-uninitialized-and-superuser-password-is-not-specified